### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @featurevisor/swift-maintainers


### PR DESCRIPTION
New GitHub team created called @featurevisor/swift-maintainers: https://github.com/orgs/featurevisor/teams/swift-maintainers

At the moment, I only added myself.

@maxgallo: please feel free to add yourself if you entertain more notifications 😬 

