### PR TITLE
test: Add base unit tests for DatafileContent decoding

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -41,5 +41,13 @@ let package = Package(
         "FeaturevisorSDK"
       ]
     ),
+    .testTarget(
+        name: "FeaturevisorTypesTests",
+        dependencies: [
+            "FeaturevisorTypes"
+        ],
+        resources: [
+            .process("JSONs")
+        ]),
   ]
 )

--- a/Tests/FeaturevisorTypesTests/FeaturevisorTypesTests.swift
+++ b/Tests/FeaturevisorTypesTests/FeaturevisorTypesTests.swift
@@ -1,0 +1,206 @@
+import Foundation
+import XCTest
+
+@testable import FeaturevisorTypes
+
+final class FeaturevisorTypesTests: XCTestCase {
+    
+    func testDecodeReturnsValidDatafileContentObjectForValidDatafileContentJSONResponse() throws {
+        
+        // GIVEN
+        let path = Bundle.module.url(forResource: "DatafileContentValidResponse", withExtension: "json")!
+        
+        // WHEN
+        let json = try Data(contentsOf: path)
+        let result = try JSONDecoder().decode(DatafileContent.self, from: json)
+        
+        // THEN
+        XCTAssertEqual(result.revision, "0.0.13")
+        XCTAssertEqual(result.schemaVersion, "1")
+        XCTAssertEqual(result.attributes.count, 3)
+        XCTAssertEqual(result.features.count, 2)
+        XCTAssertEqual(result.segments.count, 1)
+        
+        let segment = result.segments[0]
+        XCTAssertEqual(segment.key, "myAccount")
+        XCTAssertNil(segment.archived)
+        XCTAssertEqual(segment.conditions, .multiple([.plain(PlainCondition(attribute: "chapter", operator: .equals, value: .string("account")))]))
+        
+        let feature1 = result.features[0]
+        XCTAssertEqual(feature1.key, "e_bar")
+        XCTAssertNil(feature1.deprecated)
+        XCTAssertEqual(feature1.bucketBy, .single("userId"))
+        XCTAssertEqual(feature1.ranges.count, 0)
+        XCTAssertEqual(feature1.variations.count, 3)
+        XCTAssertEqual(feature1.traffic.count, 2)
+        
+        let variation1_1 = feature1.variations[0]
+        XCTAssertEqual(variation1_1.value, "control")
+        XCTAssertNil(variation1_1.description)
+        XCTAssertEqual(variation1_1.weight, 33.34)
+        XCTAssertNil(variation1_1.variables)
+        
+        let variation1_2 = feature1.variations[1]
+        XCTAssertEqual(variation1_2.value, "treatment")
+        XCTAssertNil(variation1_2.description)
+        XCTAssertEqual(variation1_2.weight, 33.33)
+        XCTAssertNil(variation1_2.variables)
+        
+        let variation1_3 = feature1.variations[2]
+        XCTAssertEqual(variation1_3.value, "anotherTreatment")
+        XCTAssertNil(variation1_3.description)
+        XCTAssertEqual(variation1_3.weight, 33.33)
+        XCTAssertNil(variation1_3.variables)
+        
+        let traffic1_1 = feature1.traffic[0]
+        XCTAssertEqual(traffic1_1.key, "1")
+        XCTAssertNil(traffic1_1.enabled)
+        XCTAssertEqual(traffic1_1.percentage, 100000)
+        XCTAssertEqual(traffic1_1.variation, nil)
+        XCTAssertEqual(traffic1_1.segments, .plain("[\"myAccount\"]"))
+        XCTAssertNil(traffic1_1.variables)
+        XCTAssertEqual(traffic1_1.allocation.count, 3)
+        
+        let allocation1_1 = traffic1_1.allocation[0]
+        XCTAssertEqual(allocation1_1.variation, "control")
+        XCTAssertEqual(allocation1_1.range.start, 0)
+        XCTAssertEqual(allocation1_1.range.end, 33340)
+        
+        let allocation1_2 = traffic1_1.allocation[1]
+        XCTAssertEqual(allocation1_2.variation, "treatment")
+        XCTAssertEqual(allocation1_2.range.start, 33340)
+        XCTAssertEqual(allocation1_2.range.end, 66670)
+        
+        let allocation1_3 = traffic1_1.allocation[2]
+        XCTAssertEqual(allocation1_3.variation, "anotherTreatment")
+        XCTAssertEqual(allocation1_3.range.start, 66670)
+        XCTAssertEqual(allocation1_3.range.end, 100000)
+        
+        let traffic1_2 = feature1.traffic[1]
+        XCTAssertEqual(traffic1_2.key, "2")
+        XCTAssertNil(traffic1_2.enabled)
+        XCTAssertEqual(traffic1_2.percentage, 0)
+        XCTAssertEqual(traffic1_2.variation, nil)
+        XCTAssertEqual(traffic1_2.segments, .plain("*"))
+        XCTAssertNil(traffic1_2.variables)
+        XCTAssertEqual(traffic1_2.allocation.count, 0)
+        
+        let feature2 = result.features[1]
+        XCTAssertEqual(feature2.key, "f_foo")
+        XCTAssertNil(feature2.deprecated)
+        XCTAssertEqual(feature2.bucketBy, .single("userId"))
+        XCTAssertEqual(feature2.ranges.count, 0)
+        XCTAssertEqual(feature2.variations.count, 0)
+        XCTAssertEqual(feature2.traffic.count, 2)
+        
+        let traffic2_1 = feature2.traffic[0]
+        XCTAssertEqual(traffic2_1.key, "1")
+        XCTAssertNil(traffic2_1.enabled)
+        XCTAssertEqual(traffic2_1.percentage, 50000)
+        XCTAssertEqual(traffic2_1.variation, nil)
+        XCTAssertEqual(traffic2_1.segments, .plain("[\"myAccount\"]"))
+        XCTAssertNil(traffic2_1.variables)
+        XCTAssertEqual(traffic2_1.allocation.count, 0)
+        
+        let traffic2_2 = feature2.traffic[1]
+        XCTAssertEqual(traffic2_2.key, "2")
+        XCTAssertNil(traffic2_2.enabled)
+        XCTAssertEqual(traffic2_2.percentage, 0)
+        XCTAssertEqual(traffic2_2.variation, nil)
+        XCTAssertEqual(traffic2_2.segments, .plain("*"))
+        XCTAssertNil(traffic2_2.variables)
+        XCTAssertEqual(traffic2_2.allocation.count, 0)
+        
+        let attribiute1 = result.attributes[0]
+        XCTAssertEqual(attribiute1.key, "chapter")
+        XCTAssertNil(attribiute1.archived)
+        XCTAssertNil(attribiute1.capture)
+        XCTAssertEqual(attribiute1.type, "string")
+        
+        let attribiute2 = result.attributes[1]
+        XCTAssertEqual(attribiute2.key, "deviceId")
+        XCTAssertNil(attribiute2.archived)
+        XCTAssertTrue(attribiute2.capture!)
+        XCTAssertEqual(attribiute2.type, "string")
+        
+        let attribiute3 = result.attributes[2]
+        XCTAssertEqual(attribiute3.key, "userId")
+        XCTAssertNil(attribiute3.archived)
+        XCTAssertTrue(attribiute3.capture!)
+        XCTAssertEqual(attribiute3.type, "string")
+    }
+}
+
+extension Condition: Equatable {
+    public static func == (lhs: Condition, rhs: Condition) -> Bool {
+        switch (lhs, rhs) {
+        case (.plain(let lhsPlain), .plain(let rhsPlain)):
+            return lhsPlain.value == rhsPlain.value
+            && lhsPlain.attribute == rhsPlain.attribute
+            && lhsPlain.operator == rhsPlain.operator
+        case (.multiple(let lhsMultiple), .multiple(let rhsMultiple)):
+            return lhsMultiple == rhsMultiple
+        case (.and(let lhsAnd), .and(let rhsAnd)):
+            return lhsAnd.and == rhsAnd.and
+        case (.or(let lhsOr), .or(let rhsOr)):
+            return lhsOr.or == rhsOr.or
+        case (.not(let lhsNot), .not(let rhsNot)):
+            return lhsNot.not == rhsNot.not
+        default:
+            return false
+        }
+    }
+}
+
+extension ConditionValue: Equatable {
+    public static func == (lhs: ConditionValue, rhs: ConditionValue) -> Bool {
+        switch (lhs, rhs) {
+        case (.string(let lhsString), .string(let rhsString)):
+            return lhsString == rhsString
+        case (.integer(let lhsInteger), .integer(let rhsInteger)):
+                return lhsInteger == rhsInteger
+        case (.double(let lhsDouble), .double(let rhsDouble)):
+            return lhsDouble == rhsDouble
+        case (.boolean(let lhsBoolean), .boolean(let rhsBoolea)):
+                return lhsBoolean == rhsBoolea
+        case (.array(let lhsArray), .array(let rhsArray)):
+            return lhsArray == rhsArray
+        default:
+            return false
+        }
+    }
+}
+
+extension BucketBy: Equatable {
+    public static func == (lhs: BucketBy, rhs: BucketBy) -> Bool {
+        switch(lhs, rhs) {
+        case (.single(let lhsSingle), .single(let rhsSingle)):
+            return lhsSingle == rhsSingle
+        case (.and(let lhsAnd), .and(let rhsAnd)):
+            return lhsAnd == rhsAnd
+        case (.or(let lhsOr), .or(let rhsOr)):
+            return lhsOr.or == rhsOr.or
+        default:
+            return false
+        }
+    }
+}
+
+extension GroupSegment: Equatable {
+    public static func == (lhs: GroupSegment, rhs: GroupSegment) -> Bool {
+        switch(lhs, rhs) {
+        case (.plain(let lhsPlain), .plain(let rhsPlain)):
+            return lhsPlain == rhsPlain
+        case (.multiple(let lhsMultiple), .multiple(let rhsMultiple)):
+            return lhsMultiple == rhsMultiple
+        case (.and(let lhsAnd), .and(let rhsAnd)):
+            return lhsAnd.and == rhsAnd.and
+        case (.or(let lhsOr), .or(let rhsOr)):
+            return lhsOr.or == rhsOr.or
+        case (.not(let lhsNot), .not(let rhsNot)):
+            return lhsNot.not == rhsNot.not
+        default:
+            return false
+        }
+    }
+}

--- a/Tests/FeaturevisorTypesTests/JSONs/DatafileContentValidResponse.json
+++ b/Tests/FeaturevisorTypesTests/JSONs/DatafileContentValidResponse.json
@@ -1,0 +1,100 @@
+{
+    "schemaVersion": "1",
+    "revision": "0.0.13",
+    "attributes": [
+        {
+            "key": "chapter",
+            "type": "string"
+        },
+        {
+            "key": "deviceId",
+            "type": "string",
+            "capture": true
+        },
+        {
+            "key": "userId",
+            "type": "string",
+            "capture": true
+        }
+    ],
+    "segments": [
+        {
+            "key": "myAccount",
+            "conditions": "[{\"attribute\":\"chapter\",\"operator\":\"equals\",\"value\":\"account\"}]"
+        }
+    ],
+    "features": [
+        {
+            "key": "e_bar",
+            "bucketBy": "userId",
+            "variations": [
+                {
+                    "value": "control",
+                    "weight": 33.34
+                },
+                {
+                    "value": "treatment",
+                    "weight": 33.33
+                },
+                {
+                    "value": "anotherTreatment",
+                    "weight": 33.33
+                }
+            ],
+            "traffic": [
+                {
+                    "key": "1",
+                    "segments": "[\"myAccount\"]",
+                    "percentage": 100000,
+                    "allocation": [
+                        {
+                            "variation": "control",
+                            "range": [
+                                0,
+                                33340
+                            ]
+                        },
+                        {
+                            "variation": "treatment",
+                            "range": [
+                                33340,
+                                66670
+                            ]
+                        },
+                        {
+                            "variation": "anotherTreatment",
+                            "range": [
+                                66670,
+                                100000
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "key": "2",
+                    "segments": "*",
+                    "percentage": 0,
+                    "allocation": []
+                }
+            ]
+        },
+        {
+            "key": "f_foo",
+            "bucketBy": "userId",
+            "traffic": [
+                {
+                    "key": "1",
+                    "segments": "[\"myAccount\"]",
+                    "percentage": 50000,
+                    "allocation": []
+                },
+                {
+                    "key": "2",
+                    "segments": "*",
+                    "percentage": 0,
+                    "allocation": []
+                }
+            ]
+        }
+    ]
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,6 +1,8 @@
 import FeaturevisorSDKTests
+import FeaturevisorTypesTests
 import XCTest
 
 var tests = [XCTestCaseEntry]()
 tests += FeaturevisorSDKTests.allTests()
+tests += FeaturevisorTypesTests.allTests()
 XCTMain(tests)


### PR DESCRIPTION
Base unit tests to verify DatafileContent decoding. It doesn't cover everything but will be extended when adding more decodable items to datafilecontent