### PR TITLE
feat: Update array's value to be a list of strings and extend API by getVariableArray

### DIFF
--- a/Sources/FeaturevisorSDK/Instance.swift
+++ b/Sources/FeaturevisorSDK/Instance.swift
@@ -772,15 +772,12 @@ public class FeaturevisorInstance {
           return getVariable(featureKey: featureKey, variableKey: variableKey, context: context)?.value as? Double
       }
 
-    //  func getVariableArray(
-    //    featureKey: FeatureKey,
-    //    variableKey: String,
-    //    context: Context
-    //  ) -> [String]? {
-    //      let variableValue = self.getVariable(featureKey: featureKey, variableKey: variableKey, context: context)
-    //      // TODO: implement
-    //    // return getValueByType(variableValue, "array") as string[] | undefined;
-    //  }
+      func getVariableArray(
+        featureKey: FeatureKey,
+        variableKey: String,
+        context: Context) -> [String]? {
+          return getVariable(featureKey: featureKey, variableKey: variableKey, context: context)?.value as? [String]
+      }
 
     // TODO: implement in Swift
     //    getVariableObject<T>(

--- a/Sources/FeaturevisorTypes/Types.swift
+++ b/Sources/FeaturevisorTypes/Types.swift
@@ -235,7 +235,7 @@ public enum VariableValue: Decodable {
     case string(String)
     case integer(Int)
     case double(Double)
-    case array([VariableValue])
+    case array([String])
     case object(VariableObjectValue)
     case json(String)  // @TODO: check later if this is correct
     // @TODO: handle null and undefined later
@@ -252,7 +252,7 @@ public enum VariableValue: Decodable {
             self = .double(double)
         } else if let boolean = try? container.decode(Bool.self) {
             self = .boolean(boolean)
-        } else if let array = try? container.decode([VariableValue].self) {
+        } else if let array = try? container.decode([String].self) {
             self = .array(array)
         } else if let object = try? container.decode(VariableObjectValue.self) {
             self = .object(object)

--- a/Tests/FeaturevisorTypesTests/VariableValueTests.swift
+++ b/Tests/FeaturevisorTypesTests/VariableValueTests.swift
@@ -68,13 +68,13 @@ final class VariableValueTests: XCTestCase {
     func testValueAsArray() {
         
         // GIVEN
-        let variable: VariableValue = .array([.string("item1"), .string("item2")])
+        let variable: VariableValue = .array(["item1", "item2"])
         
         // WHEN
-        let value = variable.value as! [VariableValue]
+        let value = variable.value as! [String]
         
         // THEN
-        XCTAssertEqual(value, [.string("item1"), .string("item2")])
+        XCTAssertEqual(value, ["item1", "item2"])
     }
     
     func testValueAsObject() {


### PR DESCRIPTION
When exposing `getVariableArray` function I noticed that based on below [JS SDK](https://github.com/fahad19/featurevisor/blob/main/packages/sdk/src/instance.ts#L1232) code we should have there an array of strings instead `VariableValue`

```
 getVariableArray(
    featureKey: FeatureKey | Feature,
    variableKey: string,
    context: Context = {},
  ): string[] | undefined {
    const variableValue = this.getVariable(featureKey, variableKey, context);

    return getValueByType(variableValue, "array") as string[] | undefined;
  }
```