### PR TITLE
chore: Use https for public dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
   dependencies: [
     // Dependencies declare other packages that this package depends on.
     // .package(url: /* package url */, from: "1.0.0"),
-    .package(url: "git@github.com:daisuke-t-jp/MurmurHash-Swift.git", from: "1.1.1"),
+    .package(url: "https://github.com/daisuke-t-jp/MurmurHash-Swift.git", from: "1.1.1"),
   ],
   targets: [
     // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
I prefer to use https for public repositories and SSH for private ones. Also, I have a feeling that GA is complaining about keys because of SSH instead https. Let's see.