### PR TITLE
fix: evaluate variables overridden from rules with no variations

### DIFF
--- a/Sources/FeaturevisorSDK/Instance+Feature.swift
+++ b/Sources/FeaturevisorSDK/Instance+Feature.swift
@@ -77,26 +77,29 @@ extension FeaturevisorInstance {
         logger: Logger
     ) -> MatchedTrafficAndAllocation {
 
-        var matchedAllocation: Allocation?
+        guard
+            let matchedTraffic = traffic.first(where: { traffic in
+                return allGroupSegmentsAreMatched(
+                    groupSegments: traffic.segments,
+                    context: context,
+                    datafileReader: datafileReader
+                )
+            })
+        else {
+            return (
+                matchedTraffic: nil,
+                matchedAllocation: nil
+            )
+        }
 
-        let matchedTraffic = traffic.first(where: { traffic in
-            if !allGroupSegmentsAreMatched(
-                groupSegments: traffic.segments,
-                context: context,
-                datafileReader: datafileReader
-            ) {
-                return false
-            }
-
-            matchedAllocation = getMatchedAllocation(traffic: traffic, bucketValue: bucketValue)
-
-            return matchedAllocation != nil
-        })
+        let matchedAllocation = getMatchedAllocation(
+            traffic: matchedTraffic,
+            bucketValue: bucketValue
+        )
 
         return (
             matchedTraffic: matchedTraffic,
             matchedAllocation: matchedAllocation
         )
-
     }
 }

--- a/Sources/FeaturevisorTypes/Types.swift
+++ b/Sources/FeaturevisorTypes/Types.swift
@@ -35,7 +35,12 @@ public struct Attribute: Decodable {
     public let archived: Bool?  // only available in YAML
     public let capture: Bool?
 
-    public init(key: AttributeKey, type: String, archived: Bool?, capture: Bool?) {
+    public init(
+        key: AttributeKey,
+        type: String,
+        archived: Bool? = nil,
+        capture: Bool? = nil
+    ) {
         self.key = key
         self.type = type
         self.archived = archived
@@ -184,7 +189,7 @@ public struct Segment: Codable {
     public init(
         key: SegmentKey,
         conditions: Condition,
-        archived: Bool?
+        archived: Bool? = nil
     ) {
         self.key = key
         self.conditions = conditions


### PR DESCRIPTION
### What was the bug
When matching both the Traffic (rule equivalent in generated datafiles) and their Allocation, it used to always check if an Allocation is found or not in the Traffic itself.

This was problematic because not all features have variations.

Resulting into issues when evaluating variables (in features with no variations) which have overrides from rule level, because SDK never found any allocation info for them (since they had no variations).

### What was done to solve it
When matching both Traffic and Allocation, it will return:

Traffic if segments matched (irrespective of Allocation bucket range checks), and
Allocation if bucket range checks are satisfied