### PR TITLE
Refactor: Function `getVariableObject` returns dictionary instead of a generic object

### DIFF
--- a/Sources/FeaturevisorSDK/Instance+Variable.swift
+++ b/Sources/FeaturevisorSDK/Instance+Variable.swift
@@ -72,25 +72,19 @@ extension FeaturevisorInstance {
             as? [String]
     }
 
-    public func getVariableObject<T: Decodable>(
+    public func getVariableObject(
         featureKey: FeatureKey,
         variableKey: String,
         context: Context
-    ) -> T? {
+    ) -> VariableObjectValue? {
 
-        let object =
+        return
             getVariable(
                 featureKey: featureKey,
                 variableKey: variableKey,
                 context: context
             )?
             .value as? VariableObjectValue
-
-        guard let data = try? JSONEncoder().encode(object) else {
-            return nil
-        }
-
-        return try? JSONDecoder().decode(T.self, from: data)
     }
 
     public func getVariableJSON<T: Decodable>(

--- a/Tests/FeaturevisorSDKTests/InstanceTests+Variables.swift
+++ b/Tests/FeaturevisorSDKTests/InstanceTests+Variables.swift
@@ -9,12 +9,6 @@ extension FeaturevisorInstanceTests {
     func testGetVariableObjectReturnsValidObject() {
 
         // GIVEN
-        class CustomObject: Decodable {
-            let title: String
-            let subtitle: String
-            let score: Int
-        }
-
         let variable = Variable(
             key: "hero",
             value: .object([
@@ -84,15 +78,15 @@ extension FeaturevisorInstanceTests {
         let sdk = try! createInstance(options: options)
 
         // WHEN
-        let object: CustomObject = sdk.getVariableObject(
+        let object: VariableObjectValue = sdk.getVariableObject(
             featureKey: "e_bar",
             variableKey: "hero",
             context: [:]
         )!
 
         // THEN
-        XCTAssertEqual(object.title, "Hero Title for B")
-        XCTAssertEqual(object.subtitle, "Hero Subtitle for B")
-        XCTAssertEqual(object.score, 10)
+        XCTAssertEqual(object["title"]?.value as! String, "Hero Title for B")
+        XCTAssertEqual(object["subtitle"]?.value as! String, "Hero Subtitle for B")
+        XCTAssertEqual(object["score"]?.value as! Int, 10)
     }
 }

--- a/Tests/FeaturevisorSDKTests/InstanceVariablesTests.swift
+++ b/Tests/FeaturevisorSDKTests/InstanceVariablesTests.swift
@@ -78,16 +78,16 @@ final class InstanceVariablesTests: XCTestCase {
         let sdk = try! createInstance(options: options)
 
         // WHEN
-        let object: CustomObject = sdk.getVariableObject(
+        let object: VariableObjectValue? = sdk.getVariableObject(
             featureKey: "e_bar",
             variableKey: "hero",
             context: [:]
         )!
 
         // THEN
-        XCTAssertEqual(object.title, "Hero Title for B")
-        XCTAssertEqual(object.subtitle, "Hero Subtitle for B")
-        XCTAssertEqual(object.score, 10)
+        XCTAssertEqual(object?["title"]?.value as! String, "Hero Title for B")
+        XCTAssertEqual(object?["subtitle"]?.value as! String, "Hero Subtitle for B")
+        XCTAssertEqual(object?["score"]?.value as! Int, 10)
     }
 
     func testGetVariableJSONReturnsValidObject() {
@@ -158,16 +158,16 @@ final class InstanceVariablesTests: XCTestCase {
         let sdk = try! createInstance(options: options)
 
         // WHEN
-        let object: CustomObject = sdk.getVariableJSON(
+        let object: VariableObjectValue? = sdk.getVariableJSON(
             featureKey: "e_bar",
             variableKey: "hero",
             context: [:]
         )!
 
         // THEN
-        XCTAssertEqual(object.title, "Hero Title for B")
-        XCTAssertEqual(object.subtitle, "Hero Subtitle for B")
-        XCTAssertEqual(object.score, 10)
+        XCTAssertEqual(object?["title"]?.value as! String, "Hero Title for B")
+        XCTAssertEqual(object?["subtitle"]?.value as! String, "Hero Subtitle for B")
+        XCTAssertEqual(object?["score"]?.value as! Int, 10)
     }
 }
 


### PR DESCRIPTION
GetVariableObjects returns a dictionary instead of generic object