### PR TITLE
Make init for `Feature` object public

### DIFF
--- a/Sources/FeaturevisorTypes/Types.swift
+++ b/Sources/FeaturevisorTypes/Types.swift
@@ -604,7 +604,7 @@ public struct Feature: Decodable {
         ranges = (try? container.decode([Range].self, forKey: .ranges)) ?? []
     }
 
-    internal init(
+    public init(
         key: FeatureKey,
         bucketBy: BucketBy,
         deprecated: Bool? = nil,


### PR DESCRIPTION
For those who want or need to init the `Feature` object in their client code