### PR TITLE
fix: forcing variation with variable overrides

### DIFF
--- a/Sources/FeaturevisorSDK/Instance+Evaluation.swift
+++ b/Sources/FeaturevisorSDK/Instance+Evaluation.swift
@@ -454,7 +454,7 @@ extension FeaturevisorInstance {
         // forced
         let force = findForceFromFeature(feature, context: context, datafileReader: datafileReader)
 
-        if let force, let variableValue = force.variables[variableKey] {
+        if let force, let variableValue = force.variables?[variableKey] {
             evaluation = Evaluation(
                 featureKey: feature.key,
                 reason: .forced,
@@ -498,10 +498,21 @@ extension FeaturevisorInstance {
             }
 
             // regular allocation
-            if let matchedAllocation = matchedTrafficAndAllocation.matchedAllocation {
+            var variationValue: VariationValue? = nil
+
+            if let forceVariation = force?.variation {
+                variationValue = forceVariation
+            }
+            else if let matchedAllocationVariation = matchedTrafficAndAllocation.matchedAllocation?
+                .variation
+            {
+                variationValue = matchedAllocationVariation
+            }
+
+            if let variationValue {
 
                 let variation = feature.variations.first(where: { variation in
-                    return variation.value == matchedAllocation.variation
+                    return variation.value == variationValue
                 })
 
                 if let variationVariables = variation?.variables {

--- a/Sources/FeaturevisorTypes/Types.swift
+++ b/Sources/FeaturevisorTypes/Types.swift
@@ -365,6 +365,17 @@ public struct VariableOverride: Codable {
     public let conditions: Condition?
     public let segments: GroupSegment?
 
+    internal init(
+        value: VariableValue,
+        conditions: Condition? = nil,
+        segments: GroupSegment? = nil
+    ) {
+
+        self.value = value
+        self.conditions = conditions
+        self.segments = segments
+    }
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         value = try container.decode(VariableValue.self, forKey: .value)
@@ -403,21 +414,36 @@ public typealias FeatureKey = String
 public typealias VariableValues = [VariableKey: VariableValue]
 
 public struct Force: Decodable {
+    public let variation: VariationValue?
+    public let variables: VariableValues?
+
     // one of the below must be present in YAML
     public let conditions: Condition?
     public let segments: GroupSegment?
 
     public let enabled: Bool?
-    public let variation: VariationValue
-    public let variables: VariableValues
+
+    internal init(
+        variation: VariationValue? = nil,
+        variables: VariableValues? = nil,
+        conditions: Condition? = nil,
+        segments: GroupSegment? = nil,
+        enabled: Bool? = nil
+    ) {
+        self.variation = variation
+        self.variables = variables
+        self.conditions = conditions
+        self.segments = segments
+        self.enabled = enabled
+    }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         enabled = try? container.decodeIfPresent(Bool.self, forKey: .enabled)
-        variation = try container.decode(VariationValue.self, forKey: .variation)
-        variables = try container.decode(VariableValues.self, forKey: .variables)
-        conditions = try container.decodeStringifiedIfPresent(Condition.self, forKey: .conditions)
-        segments = try container.decodeGroupSegmentIfPresent(forKey: .segments)
+        variation = try? container.decode(VariationValue.self, forKey: .variation)
+        variables = try? container.decode(VariableValues.self, forKey: .variables)
+        conditions = try? container.decodeStringifiedIfPresent(Condition.self, forKey: .conditions)
+        segments = try? container.decodeGroupSegmentIfPresent(forKey: .segments)
     }
 
     enum CodingKeys: CodingKey {


### PR DESCRIPTION
# Background
* Features can have variations: https://featurevisor.com/docs/features/#variations
* Variations can have variables: https://featurevisor.com/docs/features/#variable-types
* Furthermore, those variables inside variations can have overrides: https://featurevisor.com/docs/features/#overriding-variables

Forcing:
* Variations can be forced: https://featurevisor.com/docs/features/#force

# The issue
When forcing a variation from rules, without forcing variables, the forced variation is not honored when evaluating its variables.

# The fix
When evaluating variables, it will now check if there happens to be any forced variation.

If any forced variation, it will then honor the variation value before evaluating the variable values.

Otherwise, it will continue with its regular bucketing logic.

# Note
The issue was spotted under JS SDK where Swift SDK follows it. As a reference https://github.com/featurevisor/featurevisor/pull/236