### PR TITLE
fix: wrong negation under allGroupSegmentsAreMatched for 'not' operator

### DIFF
--- a/Sources/FeaturevisorSDK/Instance+Segments.swift
+++ b/Sources/FeaturevisorSDK/Instance+Segments.swift
@@ -72,8 +72,8 @@ extension FeaturevisorInstance {
                 }
 
             case .not(let notGroupSegment):
-                return !notGroupSegment.not.allSatisfy { groupSegment in
-                    allGroupSegmentsAreMatched(
+                return notGroupSegment.not.allSatisfy { groupSegment in
+                    !allGroupSegmentsAreMatched(
                         groupSegments: groupSegment,
                         context: context,
                         datafileReader: datafileReader

--- a/Tests/FeaturevisorSDKTests/InstanceTests+Segments.swift
+++ b/Tests/FeaturevisorSDKTests/InstanceTests+Segments.swift
@@ -1,0 +1,114 @@
+import Foundation
+import XCTest
+
+@testable import FeaturevisorSDK
+@testable import FeaturevisorTypes
+
+extension FeaturevisorInstanceTests {
+
+    func testShouldMatchWithMultipleConditionsInsideNOT() {
+
+        // GIVEN
+        var options: InstanceOptions = .default
+        options.datafile = DatafileContent(
+            schemaVersion: "1",
+            revision: "1.0",
+            attributes: [
+                .init(key: "userId", type: "string", capture: true),
+                .init(key: "country", type: "string"),
+                .init(key: "device_os", type: "string"),
+            ],
+            segments: [
+                .init(
+                    key: "CountryDE",
+                    conditions: .plain(
+                        .init(attribute: "country", operator: .equals, value: .string("de"))
+                    )
+                ),
+                .init(
+                    key: "CountryAT",
+                    conditions: .plain(
+                        .init(attribute: "country", operator: .equals, value: .string("at"))
+                    )
+                ),
+                .init(
+                    key: "CountryCH",
+                    conditions: .plain(
+                        .init(attribute: "country", operator: .equals, value: .string("ch"))
+                    )
+                ),
+                .init(
+                    key: "OsIOS",
+                    conditions: .plain(
+                        .init(
+                            attribute: "device_os",
+                            operator: .in,
+                            value: .array(["iOS", "iPadOS"])
+                        )
+                    )
+                ),
+            ],
+
+            features: [
+                .init(
+                    key: "feature_test_key",
+                    bucketBy: .single("userId"),
+                    variablesSchema: [],
+                    traffic: [
+                        .init(
+                            key: "1",
+                            segments: .multiple([
+                                .and(
+                                    .init(and: [
+                                        .plain("OsIOS"),
+                                        .not(
+                                            .init(not: [
+                                                .plain("CountryAT"),
+                                                .plain("CountryDE"),
+                                                .plain("CountryCH"),
+                                            ])
+                                        ),
+                                    ])
+                                )
+                            ]),
+                            percentage: 100000,
+                            allocation: [],
+                            variables: [:]
+                        ),
+                        .init(
+                            key: "2",
+                            segments: .plain("*"),
+                            percentage: 0,
+                            allocation: []
+                        ),
+                    ]
+                )
+            ]
+        )
+
+        let sdk = try! createInstance(options: options)
+
+        // WHEN
+        // THEN
+        XCTAssertFalse(
+            sdk.isEnabled(
+                featureKey: "feature_test_key",
+                context: [
+                    "device_os": AttributeValue.string("iOS"),
+                    "country": AttributeValue.string("de"),
+                ]
+            )
+        )
+
+        XCTAssertTrue(
+            sdk.isEnabled(
+                featureKey: "feature_test_key",
+                context: [
+                    "device_os": AttributeValue.string("iOS"),
+                    "country": AttributeValue.string("pl"),
+                ]
+            )
+        )
+    }
+
+}


### PR DESCRIPTION
### Background
Conditions can also be combined using [not](https://featurevisor.com/docs/segments/#not) operator.
```
# ...
conditions:
  not:
    - attribute: country
      operator: equals
      value: us
```
### Issue
When using `not` operator all segment groups have to match. Moreover, if at least one of the segment doesn't match at the end we get `false` positive.
### Where to fix?
In this line: https://github.com/featurevisor/featurevisor-swift/blob/6e6b4110ef3fb844fe7855b7cf720e13b402c2fd/Sources/FeaturevisorSDK/Instance%2BSegments.swift#L75

before:
```
case .not(let notGroupSegment):
return !notGroupSegment.not.allSatisfy { groupSegment in
    allGroupSegmentsAreMatched(
            groupSegments: groupSegment,
            context: context,
            datafileReader: datafileReader
```
after:
```
case .not(let notGroupSegment):
return notGroupSegment.not.allSatisfy { groupSegment in
    !allGroupSegmentsAreMatched(
            groupSegments: groupSegment,
            context: context,
            datafileReader: datafileReader
    )
}
```