### PR TITLE
feat: benchmarking option in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,47 @@ $ cp -f FeaturevisorSwiftTestRunner /usr/local/bin/featurevisor-swift-test-runne
 Now you can usage like below:
 ```
 $ cd path/to/featurevisor-project-with-yamls
-$ featurevisor-swift-test-runner .
+$ featurevisor-swift-test-runner test .
+```
+
+### Benchmarking
+You can measure how fast or slow your SDK evaluations are for particular features.
+
+The `--n` option is used to specify the number of iterations to run the benchmark for.
+
+### Feature
+To benchmark evaluating a feature itself if it is enabled or disabled via SDK's `.isEnabled()` method:
+
+```bash
+ FeaturevisorTestRunner benchmark \
+  --environment staging \
+  --feature feature_key \
+  --context '{"user_id":"123"}' \
+  -n 100
+```
+
+### Variation
+To benchmark evaluating a feature's variation via SDKs's `.getVariation()` method:
+
+```bash
+ FeaturevisorTestRunner benchmark \
+  --environment staging \
+  --feature feature_key \
+  --context '{"user_id":"123"}' \
+  --variation \
+  -n 100
+```
+
+### Variable
+To benchmark evaluating a feature's variable via SDKs's `.getVariable()` method:
+
+```bash
+ FeaturevisorTestRunner benchmark \
+  --environment staging \
+  --feature feature_key \
+  --variable variable_key \
+  --context '{"user_id":"123"}' \
+  -n 100
 ```
 
 ## License

--- a/Sources/FeaturevisorTestRunner/Extensions/TimeInterval+Init.swift
+++ b/Sources/FeaturevisorTestRunner/Extensions/TimeInterval+Init.swift
@@ -1,69 +1,45 @@
 import Foundation
 
 extension TimeInterval {
-    /**
-        Creates a new `TimeInterval` from the given number of nanoseconds.
-        - Parameter nanoseconds: The number of nanoseconds.
-     */
+    /// Creates a new `TimeInterval` from the given number of nanoseconds.
+    /// - Parameter nanoseconds: The number of nanoseconds.
     public init(nanoseconds: Double) { self = nanoseconds / 1_000_000_000 }
 
-    /**
-        Creates a new `TimeInterval` from the given number of microseconds.
-        - Parameter microseconds: The number of microseconds.
-     */
+    /// Creates a new `TimeInterval` from the given number of microseconds.
+    /// - Parameter microseconds: The number of microseconds.
     public init(microseconds: Double) { self = microseconds / 1_000_000 }
 
-    /**
-        Creates a new `TimeInterval` from the given number of milliseconds.
-        - Parameter milliseconds: The number of milliseconds.
-     */
+    /// Creates a new `TimeInterval` from the given number of milliseconds.
+    /// - Parameter milliseconds: The number of milliseconds.
     public init(milliseconds: Double) { self = milliseconds / 1_000 }
 
-    /**
-        Creates a new `TimeInterval` from the given number of seconds.
-        - Parameter seconds: The number of seconds.
-     */
+    /// Creates a new `TimeInterval` from the given number of seconds.
+    /// - Parameter seconds: The number of seconds.
     public init(seconds: Double) { self = seconds }
 
-    /**
-        Creates a new `TimeInterval` from the given number of minutes.
-        - Parameter minutes: The number of minutes.
-     */
+    /// Creates a new `TimeInterval` from the given number of minutes.
+    /// - Parameter minutes: The number of minutes.
     public init(minutes: Double) { self = minutes * 60 }
 
-    /**
-        Creates a new `TimeInterval` from the given number of hours.
-        - Parameter hours: The number of hours.
-     */
+    /// Creates a new `TimeInterval` from the given number of hours.
+    /// - Parameter hours: The number of hours.
     public init(hours: Double) { self = hours * 3_600 }
 
-    /**
-        The number of nanoseconds in the `TimeInterval`.
-     */
+    /// The number of nanoseconds in the `TimeInterval`.
     public var nanoseconds: Double { self * 1_000_000_000 }
 
-    /**
-        The number of microseconds in the `TimeInterval`.
-     */
+    /// The number of microseconds in the `TimeInterval`.
     public var microseconds: Double { self * 1_000_000 }
 
-    /**
-        The number of milliseconds in the `TimeInterval`.
-     */
+    /// The number of milliseconds in the `TimeInterval`.
     public var milliseconds: Double { self * 1_000 }
 
-    /**
-        The number of seconds in the `TimeInterval`.
-     */
+    /// The number of seconds in the `TimeInterval`.
     public var seconds: Double { self }
 
-    /**
-        The number of minutes in the `TimeInterval`.
-     */
+    /// The number of minutes in the `TimeInterval`.
     public var minutes: Double { self / 60 }
 
-    /**
-        The number of hours in the `TimeInterval`.
-     */
+    /// The number of hours in the `TimeInterval`.
     public var hours: Double { self / 3_600 }
 }

--- a/Sources/FeaturevisorTestRunner/Extensions/TimeInterval+Init.swift
+++ b/Sources/FeaturevisorTestRunner/Extensions/TimeInterval+Init.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+extension TimeInterval {
+    /**
+        Creates a new `TimeInterval` from the given number of nanoseconds.
+        - Parameter nanoseconds: The number of nanoseconds.
+     */
+    public init(nanoseconds: Double) { self = nanoseconds / 1_000_000_000 }
+
+    /**
+        Creates a new `TimeInterval` from the given number of microseconds.
+        - Parameter microseconds: The number of microseconds.
+     */
+    public init(microseconds: Double) { self = microseconds / 1_000_000 }
+
+    /**
+        Creates a new `TimeInterval` from the given number of milliseconds.
+        - Parameter milliseconds: The number of milliseconds.
+     */
+    public init(milliseconds: Double) { self = milliseconds / 1_000 }
+
+    /**
+        Creates a new `TimeInterval` from the given number of seconds.
+        - Parameter seconds: The number of seconds.
+     */
+    public init(seconds: Double) { self = seconds }
+
+    /**
+        Creates a new `TimeInterval` from the given number of minutes.
+        - Parameter minutes: The number of minutes.
+     */
+    public init(minutes: Double) { self = minutes * 60 }
+
+    /**
+        Creates a new `TimeInterval` from the given number of hours.
+        - Parameter hours: The number of hours.
+     */
+    public init(hours: Double) { self = hours * 3_600 }
+
+    /**
+        The number of nanoseconds in the `TimeInterval`.
+     */
+    public var nanoseconds: Double { self * 1_000_000_000 }
+
+    /**
+        The number of microseconds in the `TimeInterval`.
+     */
+    public var microseconds: Double { self * 1_000_000 }
+
+    /**
+        The number of milliseconds in the `TimeInterval`.
+     */
+    public var milliseconds: Double { self * 1_000 }
+
+    /**
+        The number of seconds in the `TimeInterval`.
+     */
+    public var seconds: Double { self }
+
+    /**
+        The number of minutes in the `TimeInterval`.
+     */
+    public var minutes: Double { self / 60 }
+
+    /**
+        The number of hours in the `TimeInterval`.
+     */
+    public var hours: Double { self / 3_600 }
+}

--- a/Sources/FeaturevisorTestRunner/FeaturevisorTestRunner+Benchmark.swift
+++ b/Sources/FeaturevisorTestRunner/FeaturevisorTestRunner+Benchmark.swift
@@ -7,7 +7,7 @@ extension FeaturevisorTestRunner.Benchmark {
 
     func benchmarkFeature(options: Options) {
 
-        print("Running benchmark for feature \(options.feature)...`)")
+        print("Running benchmark for feature \(options.feature)...")
 
         print("Building datafile containing all features for \(options.environment)...")
 

--- a/Sources/FeaturevisorTestRunner/FeaturevisorTestRunner+Benchmark.swift
+++ b/Sources/FeaturevisorTestRunner/FeaturevisorTestRunner+Benchmark.swift
@@ -1,0 +1,154 @@
+import Commands
+import FeaturevisorSDK
+import FeaturevisorTypes
+import Foundation
+
+extension FeaturevisorTestRunner.Benchmark {
+
+    func benchmarkFeature(options: Options) {
+
+        print("Running benchmark for feature \(options.feature)...`)")
+
+        print("Building datafile containing all features for \(options.environment)...")
+
+        let datafileBuildStart = DispatchTime.now()
+
+        // TODO: Handle this better
+        Commands.Task.run("bash -c featurevisor build")
+
+        let datafileBuildEnd = DispatchTime.now()
+        let datafileBuildDuration = TimeInterval(
+            nanoseconds: Double(
+                datafileBuildEnd.uptimeNanoseconds - datafileBuildStart.uptimeNanoseconds
+            )
+        )
+
+        print("Datafile build duration: \(datafileBuildDuration.seconds)s")
+
+        let f = try! SDKProvider.provide(
+            for: .ios,
+            under: options.environment,
+            using: "/Users/marcin.polak2/dev/workspace/featurevisor/features",
+            assertionAt: 1
+        )
+
+        print("...SDK initialized")
+
+        print("Against context: \(options.context)")
+
+        let output: Output
+
+        if let variable = options.variable {
+            print("Evaluating variable \(variable) \(options.n) times...")
+
+            output = benchmarkFeatureVariable(
+                f,
+                featureKey: options.feature,
+                variableKey: variable,
+                context: options.context,
+                n: options.n
+            )
+        }
+        else if options.variation {
+            print("Evaluating variation \(options.n) times...")
+
+            output = benchmarkFeatureVariation(
+                f,
+                feature: options.feature,
+                context: options.context,
+                n: options.n
+            )
+        }
+        else {
+            print("Evaluating flag \(options.n) times...")
+
+            output = benchmarkFeatureFlag(
+                f,
+                feature: options.feature,
+                context: options.context,
+                n: options.n
+            )
+        }
+
+        print("Evaluated value : \(String(describing: output.value))")
+        print("Total duration  : \(output.duration.milliseconds)ms")
+        print("Average duration: \((output.duration / Double(options.n)).milliseconds)ms")
+    }
+}
+
+extension FeaturevisorTestRunner.Benchmark {
+
+    func benchmarkFeatureFlag(
+        _ f: FeaturevisorInstance,
+        feature: FeatureKey,
+        context: [AttributeKey: AttributeValue],
+        n: Int
+    ) -> Output {
+
+        let start = DispatchTime.now()
+        var value: Any = false
+
+        for _ in 0...n {
+            value = f.isEnabled(featureKey: feature, context: context)
+        }
+
+        let end = DispatchTime.now()
+
+        return .init(
+            value: value,
+            duration: TimeInterval(
+                nanoseconds: Double(end.uptimeNanoseconds - start.uptimeNanoseconds)
+            )
+        )
+    }
+
+    func benchmarkFeatureVariation(
+        _ f: FeaturevisorInstance,
+        feature: FeatureKey,
+        context: [AttributeKey: AttributeValue],
+        n: Int
+    ) -> Output {
+
+        let start = DispatchTime.now()
+        var value: VariationValue? = nil
+
+        for _ in 0...n {
+            value = f.getVariation(featureKey: feature, context: context)
+        }
+
+        let end = DispatchTime.now()
+
+        return .init(
+            value: value,
+            duration: TimeInterval(
+                nanoseconds: Double(end.uptimeNanoseconds - start.uptimeNanoseconds)
+            )
+        )
+    }
+
+    func benchmarkFeatureVariable(
+        _ f: FeaturevisorInstance,
+        featureKey: FeatureKey,
+        variableKey: VariableKey,
+        context: [AttributeKey: AttributeValue],
+        n: Int
+    )
+        -> Output
+    {
+        let start = DispatchTime.now()
+        var value: VariableValue?
+
+        for _ in 0...n {
+            value = f.getVariable(featureKey: feature, variableKey: variableKey, context: context)
+        }
+
+        let end = DispatchTime.now()
+
+        return .init(
+            value: value,
+            duration: TimeInterval(
+                nanoseconds: Double(end.uptimeNanoseconds - start.uptimeNanoseconds)
+            )
+        )
+    }
+}

--- a/Sources/FeaturevisorTestRunner/FeaturevisorTestRunner.swift
+++ b/Sources/FeaturevisorTestRunner/FeaturevisorTestRunner.swift
@@ -10,237 +10,304 @@ import Yams
 struct FeaturevisorTestRunner: ParsableCommand {
 
     static let configuration = CommandConfiguration(
-        abstract:
-            "We can write test specs in the same expressive way as we defined our features to test against Featurevisor Swift SDK."
+        abstract: "Featurevisor SDK utilities.",
+        subcommands: [Test.self, Benchmark.self]
     )
+}
 
-    @Argument(help: "The path to features test directory.")
-    var featuresTestDirectoryPath: String
+extension FeaturevisorTestRunner {
 
-    @Flag(help: "If you are interested to see only the test specs that fail.")
-    var onlyFailures = false
+    struct Benchmark: ParsableCommand {
 
-    mutating func run() throws {
-
-        // Run Featurevisor CLI to build the datafiles
-        // TODO: Handle better, react on errors etc.
-        Commands.Task.run("bash -c cd \(featuresTestDirectoryPath) && featurevisor build")
-
-        let testSuits = try loadAllFeatureTestSuits(
-            featuresTestDirectoryPath: featuresTestDirectoryPath
+        static let configuration = CommandConfiguration(
+            abstract:
+                "You can measure how fast or slow your SDK evaluations are for particular features."
         )
 
-        let features = try loadAllFeatures(featuresTestDirectoryPath: featuresTestDirectoryPath)
-
-        var totalElapsedDurationInMilliseconds: UInt64 = 0
-
-        var totalTestSpecs = 0
-        var failedTestSpecs = 0
-
-        var totalAssertionsCount = 0
-        var failedAssertionsCount = 0
-
-        try testSuits.forEach({ testSuit in
-
-            // skip features which are not supported by ios, tvos
-            guard isFeatureSupported(by: [.ios, .tvos], featureKey: testSuit.feature, in: features)
-            else {
-                return
-            }
-
-            let output = FeatureResultOutputBuilder(
-                feature: testSuit.feature,
-                onlyFailures: onlyFailures
-            )
-
-            totalTestSpecs += 1
-            totalAssertionsCount += testSuit.assertions.count
-
-            var isTestSpecFailing = false
-
-            for (index, testCase) in testSuit.assertions.enumerated() {
-
-                var sdks: [Feature.Tag: [Environment: FeaturevisorInstance]] = [:]
-
-                try [Feature.Tag.ios, Feature.Tag.tvos]
-                    .forEach({ tag in
-                        let sdkProduction = try SDKProvider.provide(
-                            for: tag,
-                            under: .production,
-                            using: featuresTestDirectoryPath,
-                            assertionAt: testCase.at
-                        )
-
-                        let sdkStaging = try SDKProvider.provide(
-                            for: tag,
-                            under: .staging,
-                            using: featuresTestDirectoryPath,
-                            assertionAt: testCase.at
-                        )
-
-                        sdks[tag] = [
-                            .staging: sdkStaging,
-                            .production: sdkProduction,
-                        ]
-                    })
-
-                let isFeatureEnabledResult: Bool
-
-                var expectedValueFailures:
-                    [VariableKey: (expected: VariableValue, got: VariableValue?)] = [:]
-
-                switch testCase.environment {
-                    case .staging:
-
-                        guard
-                            isFeatureExposed(
-                                for: [.ios, .tvos],
-                                under: Environment.staging.rawValue,
-                                featureKey: testSuit.feature,
-                                in: features
-                            )
-                        else {
-                            break
-                        }
-
-                        let tag = firstTagToVerifyAgainst(
-                            tags: [.ios, .tvos],
-                            environment: .staging,
-                            featureKey: testSuit.feature,
-                            in: features
-                        )
-
-                        let startTime = DispatchTime.now()
-
-                        isFeatureEnabledResult =
-                            sdks[tag]![.staging]!
-                            .isEnabled(
-                                featureKey: testSuit.feature,
-                                context: testCase.context ?? [:]
-                            ) == testCase.expectedToBeEnabled
-
-                        testCase.expectedVariables?
-                            .forEach({ (variableKey, variableExpectedValue) in
-                                let variable = sdks[tag]![.staging]!
-                                    .getVariable(
-                                        featureKey: testSuit.feature,
-                                        variableKey: variableKey,
-                                        context: testCase.context ?? [:]
-                                    )
-
-                                if variable != variableExpectedValue {
-                                    expectedValueFailures[variableKey] = (
-                                        variableExpectedValue, variable
-                                    )
-                                }
-                            })
-
-                        let endTime = DispatchTime.now()
-
-                        let finalAssertionResult =
-                            isFeatureEnabledResult && expectedValueFailures.isEmpty
-
-                        isTestSpecFailing = isTestSpecFailing || !finalAssertionResult
-                        failedAssertionsCount =
-                            finalAssertionResult ? failedAssertionsCount : failedAssertionsCount + 1
-
-                        let elapsedTime = endTime.uptimeNanoseconds - startTime.uptimeNanoseconds
-                        totalElapsedDurationInMilliseconds += elapsedTime
-
-                        output.addAssertion(
-                            environment: testCase.environment,
-                            index: index,
-                            assertionResult: finalAssertionResult,
-                            expectedValueFailures: expectedValueFailures,
-                            description: testCase.description,
-                            elapsedTime: elapsedTime
-                        )
-
-                    case .production:
-
-                        guard
-                            isFeatureExposed(
-                                for: [.ios, .tvos],
-                                under: Environment.production.rawValue,
-                                featureKey: testSuit.feature,
-                                in: features
-                            )
-                        else {
-                            break
-                        }
-
-                        let tag = firstTagToVerifyAgainst(
-                            tags: [.ios, .tvos],
-                            environment: .production,
-                            featureKey: testSuit.feature,
-                            in: features
-                        )
-
-                        let startTime = DispatchTime.now()
-
-                        isFeatureEnabledResult =
-                            sdks[tag]![.production]!
-                            .isEnabled(
-                                featureKey: testSuit.feature,
-                                context: testCase.context ?? [:]
-                            ) == testCase.expectedToBeEnabled
-
-                        testCase.expectedVariables?
-                            .forEach({ (variableKey, variableExpectedValue) in
-                                let variable = sdks[tag]![.production]!
-                                    .getVariable(
-                                        featureKey: testSuit.feature,
-                                        variableKey: variableKey,
-                                        context: testCase.context ?? [:]
-                                    )
-
-                                if variable != variableExpectedValue {
-                                    expectedValueFailures[variableKey] = (
-                                        variableExpectedValue, variable
-                                    )
-                                }
-                            })
-
-                        let endTime = DispatchTime.now()
-
-                        let finalAssertionResult =
-                            isFeatureEnabledResult && expectedValueFailures.isEmpty
-
-                        isTestSpecFailing = isTestSpecFailing || !finalAssertionResult
-                        failedAssertionsCount =
-                            finalAssertionResult ? failedAssertionsCount : failedAssertionsCount + 1
-
-                        let elapsedTime = endTime.uptimeNanoseconds - startTime.uptimeNanoseconds
-                        totalElapsedDurationInMilliseconds += elapsedTime
-
-                        output.addAssertion(
-                            environment: testCase.environment,
-                            index: index,
-                            assertionResult: finalAssertionResult,
-                            expectedValueFailures: expectedValueFailures,
-                            description: testCase.description,
-                            elapsedTime: elapsedTime
-                        )
-                }
-            }
-
-            if let output = output.build() {
-                print(output)
-            }
-
-            failedTestSpecs = isTestSpecFailing ? failedTestSpecs + 1 : failedTestSpecs
-        })
-
-        print("\nTest specs: \(totalTestSpecs - failedTestSpecs) passed, \(failedTestSpecs) failed")
-        print(
-            "Assertions: \(totalAssertionsCount - failedAssertionsCount) passed, \(failedAssertionsCount) failed"
+        @Option(
+            help:
+                "The option is used to specify the environment which will be used for the benchmark run."
         )
+        var environment: String
 
-        print("Assertions execution duration: \(totalElapsedDurationInMilliseconds.milliseconds)ms")
+        @Option(
+            help:
+                "The option is used to specify the feature key which will be used for the benchmark run."
+        )
+        var feature: String
+
+        @Option(
+            help:
+                "The option is used to specify the context which will be used for the benchmark run."
+        )
+        var context: String
+
+        @Option(
+            name: .customShort("n"),
+            help: "The option is used to specify the number of iterations to run the benchmark for."
+        )
+        var numberOfIterations: Int
+
+        mutating func run() throws {
+            print("numberOfIterations: \(numberOfIterations)")
+            print("environment: \(environment)")
+            print("feature: \(feature)")
+            print("context: \(context)")
+        }
     }
 }
 
 extension FeaturevisorTestRunner {
+
+    struct Test: ParsableCommand {
+
+        static let configuration = CommandConfiguration(
+            abstract:
+                "We can write test specs in the same expressive way as we defined our features to test against Featurevisor Swift SDK.",
+            subcommands: [Benchmark.self]
+        )
+
+        @Argument(help: "The path to features test directory.")
+        var featuresTestDirectoryPath: String
+
+        @Flag(help: "If you are interested to see only the test specs that fail.")
+        var onlyFailures = false
+
+        mutating func run() throws {
+
+            // Run Featurevisor CLI to build the datafiles
+            // TODO: Handle better, react on errors etc.
+            Commands.Task.run("bash -c cd \(featuresTestDirectoryPath) && featurevisor build")
+
+            let testSuits = try loadAllFeatureTestSuits(
+                featuresTestDirectoryPath: featuresTestDirectoryPath
+            )
+
+            let features = try loadAllFeatures(featuresTestDirectoryPath: featuresTestDirectoryPath)
+
+            var totalElapsedDurationInMilliseconds: UInt64 = 0
+
+            var totalTestSpecs = 0
+            var failedTestSpecs = 0
+
+            var totalAssertionsCount = 0
+            var failedAssertionsCount = 0
+
+            try testSuits.forEach({ testSuit in
+
+                // skip features which are not supported by ios, tvos
+                guard
+                    isFeatureSupported(
+                        by: [.ios, .tvos],
+                        featureKey: testSuit.feature,
+                        in: features
+                    )
+                else {
+                    return
+                }
+
+                let output = FeatureResultOutputBuilder(
+                    feature: testSuit.feature,
+                    onlyFailures: onlyFailures
+                )
+
+                totalTestSpecs += 1
+                totalAssertionsCount += testSuit.assertions.count
+
+                var isTestSpecFailing = false
+
+                for (index, testCase) in testSuit.assertions.enumerated() {
+
+                    var sdks: [Feature.Tag: [Environment: FeaturevisorInstance]] = [:]
+
+                    try [Feature.Tag.ios, Feature.Tag.tvos]
+                        .forEach({ tag in
+                            let sdkProduction = try SDKProvider.provide(
+                                for: tag,
+                                under: .production,
+                                using: featuresTestDirectoryPath,
+                                assertionAt: testCase.at
+                            )
+
+                            let sdkStaging = try SDKProvider.provide(
+                                for: tag,
+                                under: .staging,
+                                using: featuresTestDirectoryPath,
+                                assertionAt: testCase.at
+                            )
+
+                            sdks[tag] = [
+                                .staging: sdkStaging,
+                                .production: sdkProduction,
+                            ]
+                        })
+
+                    let isFeatureEnabledResult: Bool
+
+                    var expectedValueFailures:
+                        [VariableKey: (expected: VariableValue, got: VariableValue?)] = [:]
+
+                    switch testCase.environment {
+                        case .staging:
+
+                            guard
+                                isFeatureExposed(
+                                    for: [.ios, .tvos],
+                                    under: Environment.staging.rawValue,
+                                    featureKey: testSuit.feature,
+                                    in: features
+                                )
+                            else {
+                                break
+                            }
+
+                            let tag = firstTagToVerifyAgainst(
+                                tags: [.ios, .tvos],
+                                environment: .staging,
+                                featureKey: testSuit.feature,
+                                in: features
+                            )
+
+                            let startTime = DispatchTime.now()
+
+                            isFeatureEnabledResult =
+                                sdks[tag]![.staging]!
+                                .isEnabled(
+                                    featureKey: testSuit.feature,
+                                    context: testCase.context ?? [:]
+                                ) == testCase.expectedToBeEnabled
+
+                            testCase.expectedVariables?
+                                .forEach({ (variableKey, variableExpectedValue) in
+                                    let variable = sdks[tag]![.staging]!
+                                        .getVariable(
+                                            featureKey: testSuit.feature,
+                                            variableKey: variableKey,
+                                            context: testCase.context ?? [:]
+                                        )
+
+                                    if variable != variableExpectedValue {
+                                        expectedValueFailures[variableKey] = (
+                                            variableExpectedValue, variable
+                                        )
+                                    }
+                                })
+
+                            let endTime = DispatchTime.now()
+
+                            let finalAssertionResult =
+                                isFeatureEnabledResult && expectedValueFailures.isEmpty
+
+                            isTestSpecFailing = isTestSpecFailing || !finalAssertionResult
+                            failedAssertionsCount =
+                                finalAssertionResult
+                                ? failedAssertionsCount : failedAssertionsCount + 1
+
+                            let elapsedTime =
+                                endTime.uptimeNanoseconds - startTime.uptimeNanoseconds
+                            totalElapsedDurationInMilliseconds += elapsedTime
+
+                            output.addAssertion(
+                                environment: testCase.environment,
+                                index: index,
+                                assertionResult: finalAssertionResult,
+                                expectedValueFailures: expectedValueFailures,
+                                description: testCase.description,
+                                elapsedTime: elapsedTime
+                            )
+
+                        case .production:
+
+                            guard
+                                isFeatureExposed(
+                                    for: [.ios, .tvos],
+                                    under: Environment.production.rawValue,
+                                    featureKey: testSuit.feature,
+                                    in: features
+                                )
+                            else {
+                                break
+                            }
+
+                            let tag = firstTagToVerifyAgainst(
+                                tags: [.ios, .tvos],
+                                environment: .production,
+                                featureKey: testSuit.feature,
+                                in: features
+                            )
+
+                            let startTime = DispatchTime.now()
+
+                            isFeatureEnabledResult =
+                                sdks[tag]![.production]!
+                                .isEnabled(
+                                    featureKey: testSuit.feature,
+                                    context: testCase.context ?? [:]
+                                ) == testCase.expectedToBeEnabled
+
+                            testCase.expectedVariables?
+                                .forEach({ (variableKey, variableExpectedValue) in
+                                    let variable = sdks[tag]![.production]!
+                                        .getVariable(
+                                            featureKey: testSuit.feature,
+                                            variableKey: variableKey,
+                                            context: testCase.context ?? [:]
+                                        )
+
+                                    if variable != variableExpectedValue {
+                                        expectedValueFailures[variableKey] = (
+                                            variableExpectedValue, variable
+                                        )
+                                    }
+                                })
+
+                            let endTime = DispatchTime.now()
+
+                            let finalAssertionResult =
+                                isFeatureEnabledResult && expectedValueFailures.isEmpty
+
+                            isTestSpecFailing = isTestSpecFailing || !finalAssertionResult
+                            failedAssertionsCount =
+                                finalAssertionResult
+                                ? failedAssertionsCount : failedAssertionsCount + 1
+
+                            let elapsedTime =
+                                endTime.uptimeNanoseconds - startTime.uptimeNanoseconds
+                            totalElapsedDurationInMilliseconds += elapsedTime
+
+                            output.addAssertion(
+                                environment: testCase.environment,
+                                index: index,
+                                assertionResult: finalAssertionResult,
+                                expectedValueFailures: expectedValueFailures,
+                                description: testCase.description,
+                                elapsedTime: elapsedTime
+                            )
+                    }
+                }
+
+                if let output = output.build() {
+                    print(output)
+                }
+
+                failedTestSpecs = isTestSpecFailing ? failedTestSpecs + 1 : failedTestSpecs
+            })
+
+            print(
+                "\nTest specs: \(totalTestSpecs - failedTestSpecs) passed, \(failedTestSpecs) failed"
+            )
+            print(
+                "Assertions: \(totalAssertionsCount - failedAssertionsCount) passed, \(failedAssertionsCount) failed"
+            )
+
+            print(
+                "Assertions execution duration: \(totalElapsedDurationInMilliseconds.milliseconds)ms"
+            )
+        }
+    }
+}
+
+extension FeaturevisorTestRunner.Test {
 
     func loadAllFeatures(featuresTestDirectoryPath: String) throws -> [Feature] {
 

--- a/Sources/FeaturevisorTestRunner/FeaturevisorTestRunner.swift
+++ b/Sources/FeaturevisorTestRunner/FeaturevisorTestRunner.swift
@@ -19,6 +19,20 @@ extension FeaturevisorTestRunner {
 
     struct Benchmark: ParsableCommand {
 
+        struct Options {
+            let environment: Environment
+            let feature: FeatureKey
+            let n: Int
+            let context: [AttributeKey: AttributeValue]
+            let variation: Bool
+            let variable: String?
+        }
+
+        struct Output {
+            let value: Any?
+            let duration: TimeInterval
+        }
+
         static let configuration = CommandConfiguration(
             abstract:
                 "You can measure how fast or slow your SDK evaluations are for particular features."
@@ -48,11 +62,35 @@ extension FeaturevisorTestRunner {
         )
         var numberOfIterations: Int
 
+        @Option(
+            help: "To benchmark evaluating a feature's variable via SDK's `.getVariable()` method."
+        )
+        var variable: String? = nil
+
+        @Flag(
+            help:
+                "To benchmark evaluating a feature's variation via SDK's `.getVariation()` method."
+        )
+        var variation: Bool = false
+
         mutating func run() throws {
-            print("numberOfIterations: \(numberOfIterations)")
-            print("environment: \(environment)")
-            print("feature: \(feature)")
-            print("context: \(context)")
+
+            let _context = try JSONDecoder()
+                .decode(
+                    [AttributeKey: AttributeValue].self,
+                    from: context.data(using: .utf8)!
+                )
+
+            let options: Options = .init(
+                environment: .init(rawValue: environment)!,
+                feature: feature,
+                n: numberOfIterations,
+                context: _context,
+                variation: variation,
+                variable: variable
+            )
+
+            benchmarkFeature(options: options)
         }
     }
 }

--- a/Sources/FeaturevisorTestRunner/Mappers/AssertionMapper.swift
+++ b/Sources/FeaturevisorTestRunner/Mappers/AssertionMapper.swift
@@ -22,9 +22,9 @@ enum AssertionMapper {
                 combinationPairs.append(newValues)
             })
 
-            let xxx = Combinations.combine(lists: combinationPairs)
+            let combinations = Combinations.combine(lists: combinationPairs)
 
-            xxx.forEach({ values in
+            combinations.forEach({ values in
 
                 var description = assertion.description
                 var at = "\(assertion.at)"


### PR DESCRIPTION
### What's done
Introduced an option to benchmark feature/variation/variable evaluations from CLI as JS SDK did (more info [here](https://github.com/featurevisor/featurevisor/pull/292))

### API
Read more in README (in diff).

To run benchmarking for a feature:

```
$  FeaturevisorTestRunner benchmark \
  --environment staging \
  --feature feature_key \
  --context '{"user_id":"123"}' \
  -n 100
```

Output will be similar to this:

```
Running benchmark for feature mob_eos_ios...
Building datafile containing all features for staging...
Datafile build duration: 0.197859334s
...SDK initialized
Against context: ["user_id": FeaturevisorTypes.AttributeValue.string("123")]
Evaluating flag 100 times...
Evaluated value : Optional(true)
Total duration  : 0.9339580000000001ms
Average duration: 0.00933958ms
```