### PR TITLE
feat: evaluate features in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,19 @@ To benchmark evaluating a feature's variable via SDKs's `.getVariable()` method:
   -n 100
 ```
 
+### Evaluate
+To learn why certain values (like feature and its variation or variables) are evaluated as they are against provided [context](https://featurevisor.com/docs/sdks/javascript/#context):
+
+```bash
+ FeaturevisorTestRunner evaluate \
+  --environment staging \
+  --feature feature_key \
+  --feature variable_key \
+  --context '{"user_id":"123"}' \
+```
+This will show you full [evaluation details](https://featurevisor.com/docs/sdks/javascript/#evaluation-details) helping you debug better in case of any confusion.
+It is similar to logging in SDKs with debug level. But here instead, we are doing it at CLI directly in our Featurevisor project without having to involve our application(s).
+
 ## License
 
 [MIT](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -393,7 +393,6 @@ To learn why certain values (like feature and its variation or variables) are ev
  FeaturevisorTestRunner evaluate \
   --environment staging \
   --feature feature_key \
-  --feature variable_key \
   --context '{"user_id":"123"}' \
 ```
 This will show you full [evaluation details](https://featurevisor.com/docs/sdks/javascript/#evaluation-details) helping you debug better in case of any confusion.

--- a/Sources/FeaturevisorSDK/Instance+Feature.swift
+++ b/Sources/FeaturevisorSDK/Instance+Feature.swift
@@ -13,23 +13,35 @@ extension FeaturevisorInstance {
         _ feature: Feature,
         context: Context,
         datafileReader: DatafileReader
-    ) -> Force? {
+    ) -> ForceResult {
 
-        return feature.force.first(where: { force in
-            if let conditions = force.conditions {
-                return allConditionsAreMatched(condition: conditions, context: context)
+        var force: Force?
+        var forceIndex: Int?
+
+        for (index, currentForce) in feature.force.enumerated() {
+            if let condition = currentForce.conditions,
+                allConditionsAreMatched(condition: condition, context: context)
+            {
+
+                force = currentForce
+                forceIndex = index
+                break
             }
 
-            if let segments = force.segments {
-                return allGroupSegmentsAreMatched(
+            if let segments = currentForce.segments,
+                allGroupSegmentsAreMatched(
                     groupSegments: segments,
                     context: context,
                     datafileReader: datafileReader
                 )
+            {
+                force = currentForce
+                forceIndex = index
+                break
             }
+        }
 
-            return false
-        })
+        return .init(force: force, forceIndex: forceIndex)
     }
 
     func getMatchedTraffic(

--- a/Sources/FeaturevisorSDK/Instance.swift
+++ b/Sources/FeaturevisorSDK/Instance.swift
@@ -32,9 +32,13 @@ public struct Evaluation: Codable {
     private enum CodingKeys: String, CodingKey {
         case featureKey
         case reason
+        case bucketKey
         case bucketValue
         case ruleKey
+        case error
         case enabled
+        case forceIndex
+        case force
         case traffic
         case sticky
         case initial
@@ -50,10 +54,13 @@ public struct Evaluation: Codable {
     public let reason: EvaluationReason
 
     // common
+    public let bucketKey: BucketKey?
     public let bucketValue: BucketValue?
     public let ruleKey: RuleKey?
     public let enabled: Bool?
     public let traffic: Traffic?
+    public let forceIndex: Int?
+    public let force: Force?
     public let sticky: OverrideFeature?
     public let initial: OverrideFeature?
 
@@ -69,10 +76,13 @@ public struct Evaluation: Codable {
     public init(
         featureKey: FeatureKey,
         reason: EvaluationReason,
+        bucketKey: BucketKey? = nil,
         bucketValue: BucketValue? = nil,
         ruleKey: RuleKey? = nil,
         enabled: Bool? = nil,
         traffic: Traffic? = nil,
+        forceIndex: Int? = nil,
+        force: Force? = nil,
         sticky: OverrideFeature? = nil,
         initial: OverrideFeature? = nil,
         variation: Variation? = nil,
@@ -83,10 +93,13 @@ public struct Evaluation: Codable {
     ) {
         self.featureKey = featureKey
         self.reason = reason
+        self.bucketKey = bucketKey
         self.bucketValue = bucketValue
         self.ruleKey = ruleKey
         self.enabled = enabled
         self.traffic = traffic
+        self.forceIndex = forceIndex
+        self.force = force
         self.sticky = sticky
         self.initial = initial
         self.variation = variation
@@ -101,9 +114,12 @@ public struct Evaluation: Codable {
 
         try container.encode(featureKey, forKey: .featureKey)
         try container.encode(reason.rawValue, forKey: .reason)
+        try container.encodeIfPresent(bucketKey, forKey: .bucketKey)
         try container.encodeIfPresent(bucketValue, forKey: .bucketValue)
         try container.encodeIfPresent(ruleKey, forKey: .ruleKey)
         try container.encodeIfPresent(enabled, forKey: .enabled)
+        try container.encodeIfPresent(forceIndex, forKey: .forceIndex)
+        try container.encodeIfPresent(force, forKey: .force)
         try container.encodeIfPresent(traffic, forKey: .traffic)
         try container.encodeIfPresent(sticky, forKey: .sticky)
         try container.encodeIfPresent(initial, forKey: .initial)
@@ -120,9 +136,12 @@ public struct Evaluation: Codable {
         featureKey = try container.decode(FeatureKey.self, forKey: .featureKey)
         reason =
             try EvaluationReason(rawValue: container.decode(String.self, forKey: .reason)) ?? .error
+        bucketKey = try container.decodeIfPresent(BucketKey.self, forKey: .bucketKey)
         bucketValue = try container.decodeIfPresent(BucketValue.self, forKey: .bucketValue)
         ruleKey = try? container.decodeIfPresent(RuleKey.self, forKey: .ruleKey)
         enabled = try? container.decodeIfPresent(Bool.self, forKey: .enabled)
+        forceIndex = try? container.decodeIfPresent(Int.self, forKey: .forceIndex)
+        force = try? container.decodeIfPresent(Force.self, forKey: .force)
         traffic = try? container.decodeIfPresent(Traffic.self, forKey: .traffic)
         sticky = try? container.decodeIfPresent(OverrideFeature.self, forKey: .sticky)
         initial = try? container.decodeIfPresent(OverrideFeature.self, forKey: .initial)

--- a/Sources/FeaturevisorSDK/Logger.swift
+++ b/Sources/FeaturevisorSDK/Logger.swift
@@ -24,7 +24,7 @@ public class Logger {
     var levels: [LogLevel]
     let handle: LogHandler
 
-    init(levels: [LogLevel], handle: @escaping LogHandler) {
+    public init(levels: [LogLevel], handle: @escaping LogHandler) {
         self.levels = levels
         self.handle = handle
     }

--- a/Sources/FeaturevisorTestRunner/Extensions/Evaluation+CustomStringConvertible.swift
+++ b/Sources/FeaturevisorTestRunner/Extensions/Evaluation+CustomStringConvertible.swift
@@ -1,0 +1,55 @@
+import FeaturevisorSDK
+
+extension Evaluation: EvaluationStringConvertible {}
+
+private protocol EvaluationStringConvertible: CustomStringConvertible {}
+
+extension EvaluationStringConvertible {
+
+    public var description: String {
+        let ignoreKeys = [
+            "featureKey", "variableKey", "variation", "variableSchema", "traffic", "force",
+        ]
+
+        let mirror = Mirror(reflecting: self)
+
+        let output: [String] = mirror
+            .allChildren
+            .sorted {
+                $0.label ?? "" < $1.label ?? ""
+            }
+            .compactMap { (key: String?, value: Any) in
+                guard let key, !ignoreKeys.contains(key) else {
+                    return nil
+                }
+
+                switch value {
+                    case Optional<Any>.none:
+                        return nil
+                    case Optional<Any>.some(let wrapped):
+                        return "- \(key): \(wrapped)"
+                    default:
+                        return nil
+                }
+            }
+
+        return "\(output.joined(separator: "\n"))"
+    }
+}
+
+extension Mirror {
+
+    /// The children of the mirror and its superclasses.
+    fileprivate var allChildren: [Mirror.Child] {
+        var children = Array(self.children)
+
+        var superclassMirror = self.superclassMirror
+
+        while let mirror = superclassMirror {
+            children.append(contentsOf: mirror.children)
+            superclassMirror = mirror.superclassMirror
+        }
+
+        return children
+    }
+}

--- a/Sources/FeaturevisorTestRunner/FeaturevisorTestRunner+Evaluate.swift
+++ b/Sources/FeaturevisorTestRunner/FeaturevisorTestRunner+Evaluate.swift
@@ -1,0 +1,112 @@
+import Commands
+import FeaturevisorSDK
+import FeaturevisorTypes
+import Foundation
+
+extension FeaturevisorTestRunner.Evaluate {
+
+    func evaluateFeature(options: Options) {
+
+        // TODO: Handle this better
+        Commands.Task.run("bash -c featurevisor build")
+
+        let f = try! SDKProvider.provide(
+            for: .ios,
+            under: options.environment,
+            using: ".",
+            assertionAt: 1
+        )
+
+        let flagEvaluation = f.evaluateFlag(featureKey: options.feature, context: options.context)
+        let variationEvaluation = f.evaluateVariation(
+            featureKey: options.feature,
+            context: options.context
+        )
+
+        var variableEvaluations: [VariableKey: Evaluation] = [:]
+        let feature = f.getFeature(byKey: options.feature)
+
+        feature?.variablesSchema
+            .forEach({ variableSchema in
+                let variableEvaluation = f.evaluateVariable(
+                    featureKey: options.feature,
+                    variableKey: variableSchema.key,
+                    context: options.context
+                )
+
+                variableEvaluations[variableSchema.key] = variableEvaluation
+            })
+
+        print(
+            "Evaluating feature \(options.feature) in environment \(options.environment.rawValue)..."
+        )
+        print("Against context: \(options.context)")  // TODO: pretty
+
+        // flag
+        printHeader("Is enabled?")
+
+        print("Value: \(flagEvaluation.enabled ?? false)")
+        print("\nDetails:\n")
+
+        printEvaluationDetails(flagEvaluation)
+
+        // variation
+        printHeader("Variation")
+
+        if let variation = variationEvaluation.variation {
+            print("Value: \(variation.value)")
+
+            print("\nDetails:\n")
+
+            printEvaluationDetails(variationEvaluation)
+        }
+        else {
+            print("No variations defined.")
+        }
+
+        // variables
+        if !variableEvaluations.isEmpty {
+            variableEvaluations.forEach({ variableKey, evaluation in
+                printHeader("Variable: \(variableKey)")
+
+                if let variableValue = evaluation.variableValue {
+                    print("Value: \(variableValue)")
+                }
+                else {
+                    print("Value: nil")
+                }
+
+                print("\nDetails:\n")
+
+                printEvaluationDetails(evaluation)
+            })
+        }
+        else {
+            printHeader("Variables")
+            print("No variables defined.")
+        }
+    }
+}
+
+extension FeaturevisorTestRunner.Evaluate {
+
+    fileprivate func printHeader(_ message: String) {
+        print("\n\n###############")
+        print(" \(message)")
+        print("###############\n")
+    }
+
+    fileprivate func printEvaluationDetails(_ evaluation: Evaluation) {
+
+        if let variation = evaluation.variation {
+            print("- variation: \(variation.value)")
+        }
+
+        if let variableSchema = evaluation.variableSchema {
+            print("- variableType: \(variableSchema.type)")
+            print("- defaultValue: \(variableSchema.defaultValue)")
+        }
+
+        print(evaluation)
+    }
+}

--- a/Sources/FeaturevisorTestRunner/FeaturevisorTestRunner.swift
+++ b/Sources/FeaturevisorTestRunner/FeaturevisorTestRunner.swift
@@ -11,7 +11,7 @@ struct FeaturevisorTestRunner: ParsableCommand {
 
     static let configuration = CommandConfiguration(
         abstract: "Featurevisor SDK utilities.",
-        subcommands: [Test.self, Benchmark.self]
+        subcommands: [Benchmark.self, Evaluate.self, Test.self]
     )
 }
 
@@ -91,6 +91,63 @@ extension FeaturevisorTestRunner {
             )
 
             benchmarkFeature(options: options)
+        }
+    }
+}
+
+extension FeaturevisorTestRunner {
+
+    struct Evaluate: ParsableCommand {
+
+        struct Options {
+            let environment: Environment
+            let feature: FeatureKey
+            let context: [AttributeKey: AttributeValue]
+        }
+
+        struct Output {
+            let value: Any?
+            let duration: TimeInterval
+        }
+
+        static let configuration = CommandConfiguration(
+            abstract:
+                "To learn why certain values (like feature and its variation or variables) are evaluated as they are."
+        )
+
+        @Option(
+            help:
+                "The option is used to specify the environment which will be used for the evaluation run."
+        )
+        var environment: String
+
+        @Option(
+            help:
+                "The option is used to specify the feature key which will be used for the evaluation run."
+        )
+        var feature: String
+
+        @Option(
+            help:
+                "The option is used to specify the context which will be used for the benchmark run."
+        )
+        var context: String
+
+        mutating func run() throws {
+
+            let _context = try JSONDecoder()
+                .decode(
+                    [AttributeKey: AttributeValue].self,
+                    from: context.data(using: .utf8)!
+                )
+
+            let options: Options = .init(
+                environment: .init(rawValue: environment)!,
+                feature: feature,
+                context: _context
+            )
+
+            evaluateFeature(options: options)
         }
     }
 }

--- a/Sources/FeaturevisorTestRunner/Models/SDKProvider.swift
+++ b/Sources/FeaturevisorTestRunner/Models/SDKProvider.swift
@@ -46,6 +46,8 @@ enum SDKProvider {
         options.configureBucketValue = { _, _, _ -> BucketValue in
             return Int(assertionAt * (maxBucketedNumber / 100.0))
         }
+        options.logger = Logger(levels: []) { _, _, _ in
+        }
 
         return try FeaturevisorSDK.createInstance(options: options)
     }

--- a/Sources/FeaturevisorTypes/Types.swift
+++ b/Sources/FeaturevisorTypes/Types.swift
@@ -505,7 +505,17 @@ public typealias FeatureKey = String
 
 public typealias VariableValues = [VariableKey: VariableValue]
 
-public struct Force: Decodable {
+public struct ForceResult {
+    public let force: Force?
+    public let forceIndex: Int?
+
+    public init(force: Force?, forceIndex: Int?) {
+        self.force = force
+        self.forceIndex = forceIndex
+    }
+}
+
+public struct Force: Codable {
     public let variation: VariationValue?
     public let variables: VariableValues?
 


### PR DESCRIPTION
### What's done
For debugging purposes, a new command has been introduced:

```
 FeaturevisorTestRunner evaluate \
  --environment staging \
  --feature feature_key \
  --feature variable_key \
  --context '{"user_id":"123"}'
```

Example output:
```
Evaluating feature e_bar in environment staging...
Against context: ["user_id": FeaturevisorTypes.AttributeValue.string("123")]


###############
 Is enabled?
###############

Value: true

Details:

- bucketKey: e_bar
- bucketValue: 1000
- enabled: true
- reason: rule
- ruleKey: 1


###############
 Variation
###############

Value: control

Details:

- variation: control
- bucketKey: e_bar
- bucketValue: 1000
- reason: allocated
- ruleKey: 1


###############
 Variable: color
###############

Value: string("red")

Details:

- variableType: string
- defaultValue: string("red")
- bucketKey: e_bar
- bucketValue: 1000
- reason: defaulted
- variableValue: string("red")


###############
 Variable: hero
###############

Value: object(["alignment": FeaturevisorTypes.VariableValue.string("center for B"), "subtitle": FeaturevisorTypes.VariableValue.string("Hero Subtitle for B"), "title": FeaturevisorTypes.VariableValue.string("Hero Title for B")])

Details:

- variableType: object
- defaultValue: object(["alignment": FeaturevisorTypes.VariableValue.string("center"), "subtitle": FeaturevisorTypes.VariableValue.string("Hero Subtitle"), "title": FeaturevisorTypes.VariableValue.string("Hero Title")])
- bucketKey: e_bar
- bucketValue: 1000
- reason: allocated
- ruleKey: 1
- variableValue: object(["alignment": FeaturevisorTypes.VariableValue.string("center for B"), "subtitle": FeaturevisorTypes.VariableValue.string("Hero Subtitle for B"), "title": FeaturevisorTypes.VariableValue.string("Hero Title for B")])
```

As a reference https://github.com/featurevisor/featurevisor/pull/295