### PR TITLE
fix: handle non-stringified segments under force

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,50 @@
+{
+  "pins" : [
+    {
+      "identity" : "files",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/JohnSundell/Files",
+      "state" : {
+        "revision" : "d273b5b7025d386feef79ef6bad7de762e106eaf",
+        "version" : "4.2.0"
+      }
+    },
+    {
+      "identity" : "murmurhash-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/daisuke-t-jp/MurmurHash-Swift.git",
+      "state" : {
+        "revision" : "7e69bedaaaea09673524d83de12dac6e09d5b74a",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "41982a3656a71c768319979febd796c6fd111d5c",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swift-commands",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/qiuzhifei/swift-commands",
+      "state" : {
+        "revision" : "ed3de1c1057f4e3a5b0371d0762facd7c9a3dace",
+        "version" : "0.7.0"
+      }
+    },
+    {
+      "identity" : "yams",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/Yams.git",
+      "state" : {
+        "revision" : "b4b8042411dc7bbb696300a34a4bf3ba1b7ad19b",
+        "version" : "5.3.1"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Tests/FeaturevisorTypesTests/JSONs/DatafileContentValidResponse.json
+++ b/Tests/FeaturevisorTypesTests/JSONs/DatafileContentValidResponse.json
@@ -129,12 +129,14 @@
       ],
       "force": [
         {
-        "segments": "[\"OsTvOS\"]",
-        "variation": "anotherTreatment",
-        "variables": {
-          "bar": "force_bar"
-        },
-        "enabled": true
+          "segments": [
+            "OsTvOS"
+          ],
+          "variation": "anotherTreatment",
+          "variables": {
+            "bar": "force_bar"
+          },
+          "enabled": true
         },
         {
           "conditions": {


### PR DESCRIPTION
In case the segment section is non-stringified like below, it won't be parsed correctly:

```json
     ....
      "force": [
        {
          "segments": [
            "OsTvOS"
          ],
          "variation": "anotherTreatment",
          "variables": {
            "bar": "force_bar"
          },
          "enabled": true
        },
     ....
```

After this change, we will parse the above and below segment sections correctly:

```json
     ....
      "force": [
        {
          "segments": "[\"OsTvOS\"]",
          "variation": "anotherTreatment",
          "variables": {
            "bar": "force_bar"
          },
          "enabled": true
        },
     ....
```