### PR TITLE
refactor: Handle matrix variable declarations with and without whitespaces

### DIFF
--- a/Sources/Featurevisor/Mappers/AssertionMapper.swift
+++ b/Sources/Featurevisor/Mappers/AssertionMapper.swift
@@ -70,6 +70,43 @@ enum AssertionMapper {
 extension AssertionMapper {
 
     fileprivate static func replace(source: String, key: String, value: String) -> String {
-        return source.replacingOccurrences(of: "${{ \(key) }}", with: value)
+        return removeAllWhitespaceInsidePlaceholders(in: source)
+            .replacingOccurrences(of: "${{\(key)}}", with: value)
+    }
+
+    fileprivate static func removeAllWhitespaceInsidePlaceholders(in input: String) -> String {
+        let pattern = "\\$\\{\\{\\s*(.*?)\\s*\\}\\}"
+        let regex = try! NSRegularExpression(pattern: pattern, options: [])
+
+        let nsrange = NSRange(input.startIndex..<input.endIndex, in: input)
+        var result = input
+        var offset = 0
+
+        regex.enumerateMatches(in: input, options: [], range: nsrange) { match, _, _ in
+            guard let match = match, match.numberOfRanges == 2,
+                let innerRange = Range(match.range(at: 1), in: input)
+            else {
+                return
+            }
+
+            let originalInner = String(input[innerRange])
+            let cleaned = originalInner.replacingOccurrences(
+                of: #"\s+"#,
+                with: "",
+                options: .regularExpression
+            )
+
+            // Rebuild the full match range considering offset due to replacements
+            let fullMatchRange = match.range(at: 0)
+            if let rangeToReplace = Range(
+                NSRange(location: fullMatchRange.location + offset, length: fullMatchRange.length),
+                in: result
+            ) {
+                result.replaceSubrange(rangeToReplace, with: "${{\(cleaned)}}")
+                offset += "${{\(cleaned)}}".count - fullMatchRange.length
+            }
+        }
+
+        return result
     }
 }


### PR DESCRIPTION
Now, the matrix variables have to be declered in a format like "${{ NAME }}" so in case if someone writes "${{NAME}} then it won't be handled correctly. Now, we remove all whitespaces between "${{ NAME }}" and then try to replace